### PR TITLE
Fix MVC static web assets packaging

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<!--Increment the VersionPrefix at begining of new release cycle--> 
-		<VersionPrefix>0.1.0</VersionPrefix>
+		<!--Increment the VersionPrefix at beginning of new release cycle--> 
+		<VersionPrefix>0.10.0</VersionPrefix>
 		<Version>$(VersionPrefix)</Version>
 		<AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
 		<FileVersion>$(VersionPrefix).0</FileVersion>

--- a/src/Starbender.Mazer.Mvc/Starbender.Mazer.Mvc.csproj
+++ b/src/Starbender.Mazer.Mvc/Starbender.Mazer.Mvc.csproj
@@ -14,14 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="wwwroot\**\*.*" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Remove="wwwroot\**\*.*" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="..\favicon.ico" Link="wwwroot\favicon.ico" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- package MVC `wwwroot` files as static web assets instead of embedded resources
- restore `layout.css` and `layout.js` under `/_content/Starbender.Mazer.Mvc/...`
- bump package version to `0.10.0`

## Verification
- repacked `Starbender.Mazer.Mvc`
- confirmed `layout.css`, `layout.js`, `googlefonts.css`, and `logo.png` are present in the `.nupkg`
