### PR TITLE
Fix duplicate resize observer registration

### DIFF
--- a/demo/WebApp/Mazer.WebAppDemo/Components/App.razor
+++ b/demo/WebApp/Mazer.WebAppDemo/Components/App.razor
@@ -17,7 +17,7 @@
     <title>Mazer.WebAppDemo</title>
     <base href="/" />
 
-    <AbpStyles BundleName="@BlazorStandardBundles.Styles.Global" WebAssemblyStyleFiles="GlobalStyles" @rendermode="InteractiveAuto" />
+    <AbpStyles BundleName="@BlazorStandardBundles.Styles.Global" @rendermode="InteractiveAuto" />
 
     <link href="Mazer.WebAppDemo.styles.css" rel="stylesheet"/>
     <link href="Mazer.WebAppDemo.Client.styles.css" rel="stylesheet"/>
@@ -43,21 +43,9 @@
         <a class="dismiss">🗙</a>
     </div>
     
-    <AbpScripts BundleName="@BlazorStandardBundles.Scripts.Global" WebAssemblyScriptFiles="GlobalScripts" @rendermode="InteractiveAuto" />
+    <AbpScripts BundleName="@BlazorStandardBundles.Scripts.Global" @rendermode="InteractiveAuto" />
 
     <script src="_framework/blazor.web.js"></script>
 
 </body>
 </html>
-
-@code{
-    private List<string> GlobalStyles =>
-    [
-        "global.css"
-    ];
-
-    private List<string> GlobalScripts =>
-    [
-        "global.js"
-    ];
-}


### PR DESCRIPTION
## Summary

Removes the extra `WebAssemblyStyleFiles` and `WebAssemblyScriptFiles` wiring from the WebApp host so the global ABP bundles are rendered only once under `InteractiveAuto`.

This fixes the duplicate MudBlazor resize observer script registration and related browser console noise caused by overlapping global asset injection paths in the WebApp demo.

Closes #17.

## Testing

- [x] I built the relevant projects locally
- [ ] I ran tests relevant to this change
- [ ] I updated documentation when needed

## Checklist

- [x] This PR targets the correct branch
- [x] This change is scoped to a single feature, fix, or refactor
- [x] Related issues are linked when applicable
