### PR TITLE
Fix package version inheritance and main PR source policy

### DIFF
--- a/.github/workflows/enforce-main-pr-source.yml
+++ b/.github/workflows/enforce-main-pr-source.yml
@@ -1,0 +1,21 @@
+name: Enforce Main PR Source
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  require-development-source:
+    name: Require Development Source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure pull requests into main come from development
+        run: |
+          if [ "${{ github.head_ref }}" != "development" ]; then
+            echo "Only pull requests from development may target main."
+            exit 1
+          fi

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
 
 	<PropertyGroup>
 		<!--Increment the VersionPrefix at beginning of new release cycle--> 
-		<VersionPrefix>0.10.0</VersionPrefix>
+		<VersionPrefix>1.0.1</VersionPrefix>
 		<Version>$(VersionPrefix)</Version>
 		<AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
 		<FileVersion>$(VersionPrefix).0</FileVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,6 @@
 <Project>
+	<Import Project="..\Directory.Build.props" />
+
 	<PropertyGroup>
 		<AbpProjectType>module</AbpProjectType>
 		<RepositoryUrl>https://github.com/Starbender-Systems/Starbender.Mazer.git</RepositoryUrl>


### PR DESCRIPTION
## Summary

Addresses the versioning and merge-policy work tracked in #24.

This branch includes:
- a fix for package version inheritance under `src/` by importing the repo-root `Directory.Build.props` from `src/Directory.Build.props`
- a version bump in the repo-root `Directory.Build.props` from `0.10.0` to `1.0.1`
- a new GitHub Actions workflow that enforces pull requests into `main` must come from `development`

Closes #24.

## Testing

- [x] I built the relevant projects locally
- [ ] I ran tests relevant to this change
- [ ] I updated documentation when needed

## Checklist

- [x] This PR targets the correct branch
- [x] This change is scoped to a single feature, fix, or refactor
- [x] Related issues are linked when applicable
