### PR TITLE
Clarify ABP 10.0.2 compatibility and fix WebApp asset loading

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
 
 	<PropertyGroup>
 		<!--Increment the VersionPrefix at beginning of new release cycle--> 
-		<VersionPrefix>1.0.2</VersionPrefix>
+		<VersionPrefix>1.0.3</VersionPrefix>
 		<Version>$(VersionPrefix)</Version>
 		<AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
 		<FileVersion>$(VersionPrefix).0</FileVersion>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The goal of the project is to give ABP applications a consistent, modern look an
 Mazer supports Mvc, Blazor Server, Blazor WebAssembly (WASM) and hybrid Blazor WebApp models.
 See the [Migration Guide](docs/Migration.md) for instructions on migrating your ABP UI application to Mazer.
 
+## Compatibility
+The current `1.0.2` package line in this repository is pinned to ABP `10.0.2`.
+Consumers using ABP `10.1.x` should treat that as the current dependency baseline unless a later Mazer release explicitly retargets those package references.
+
 ## Community
 - Contribution guide: [`CONTRIBUTING.md`](.github/CONTRIBUTING.md)
 - Code of conduct: [`CODE_OF_CONDUCT.md`](.github/CODE_OF_CONDUCT.md)

--- a/demo/WebApp/Mazer.WebAppDemo/Components/App.razor
+++ b/demo/WebApp/Mazer.WebAppDemo/Components/App.razor
@@ -16,7 +16,7 @@
     <title>Mazer.WebAppDemo</title>
     <base href="/" />
 
-    <AbpStyles BundleName="@BlazorMazerBundles.Styles.Global" @rendermode="InteractiveAuto" />
+    <AbpStyles BundleName="@BlazorMazerBundles.Styles.Global" WebAssemblyStyleFiles="GlobalStyles" @rendermode="InteractiveAuto" />
 
     <link href="Mazer.WebAppDemo.styles.css" rel="stylesheet"/>
     <link href="Mazer.WebAppDemo.Client.styles.css" rel="stylesheet"/>
@@ -42,9 +42,14 @@
         <a class="dismiss">🗙</a>
     </div>
     
-    <AbpScripts BundleName="@BlazorMazerBundles.Scripts.Global" @rendermode="InteractiveAuto" />
+    <AbpScripts BundleName="@BlazorMazerBundles.Scripts.Global" WebAssemblyScriptFiles="GlobalScripts" @rendermode="InteractiveAuto" />
 
     <script src="_framework/blazor.web.js"></script>
 
 </body>
 </html>
+
+@code {
+    private List<string> GlobalStyles => ["global.css"];
+    private List<string> GlobalScripts => ["global.js"];
+}

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -75,6 +75,7 @@ Notes:
 - `MazerMvcModule` is still important for applications that expose MVC / Razor Pages endpoints, including account and host pages.
 - `MazerWebAssemblyBundlingModule` is the piece that adds `Starbender.Mazer.Blazor` assets into ABP's Blazor WebAssembly global asset pipeline.
 - In some hosted Blazor WebAssembly solutions, the host may resolve `MazerWebAssemblyBundlingModule` transitively through the client project. If that is not true in your solution, add a direct package reference for the needed assembly.
+- The current source tree and published `1.0.2` packages remain pinned to ABP `10.0.2`. This guide does not imply a retarget to ABP `10.1.x`.
 
 ## MVC / Razor Pages
 
@@ -410,10 +411,14 @@ PreConfigure<AbpAspNetCoreComponentsWebOptions>(options =>
 In the server project startup/module:
 
 ```csharp
+using Volo.Abp.AspNetCore.Mvc.UI.Theme.Shared;
+
 context.Services.AddRazorComponents()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
 ```
+
+Keep the `Theme.Shared` import in scope in module examples that also call `app.UseErrorPage()`, because that extension method is provided there.
 
 ### 4. Configure all three bundle surfaces
 
@@ -467,6 +472,8 @@ private void ConfigureBundles()
 ### 5. Update `App.razor` for `InteractiveAuto`
 
 Use `BlazorMazerBundles` for the server side and pass the generated WebAssembly files through `WebAssemblyStyleFiles` and `WebAssemblyScriptFiles`.
+
+These attributes are required when the host contributes to `BlazorMazerWebAssemblyBundles` and expects the generated `global.css` and `global.js` files to be loaded by the Blazor WebApp shell.
 
 Representative structure:
 

--- a/src/Starbender.Mazer.Blazor/Nuget.md
+++ b/src/Starbender.Mazer.Blazor/Nuget.md
@@ -1,3 +1,6 @@
 # Starbender.Mazer.Blazor
 ## ℹ️ Description
 A full featured UI theme kit for [ABP Framework](https://abp.io) applications. It supports Blazor Server, WebAssembly and WebApp architectures. Blazor theme components are based on [MudBlazor](https://mudblazor.com). In addition, MVC UI apps are supported and consistent components are provided to produce a consistent look and feel across all UI technologies.
+
+## Compatibility
+The current `1.0.2` package line targets ABP `10.0.2`. This package is not retargeted to ABP `10.1.x` in this release line.

--- a/src/Starbender.Mazer.Installer/Nuget.md
+++ b/src/Starbender.Mazer.Installer/Nuget.md
@@ -1,3 +1,6 @@
 # Starbender.Mazer.Blazor
 ## ℹ️ Description
 A full featured UI theme kit for [ABP Framework](https://abp.io) applications. It supports Blazor Server, WebAssembly and WebApp architectures. Blazor theme components are based on [MudBlazor](https://mudblazor.com). In addition, MVC UI apps are supported and consistent components are provided to produce a consistent look and feel across all UI technologies.
+
+## Compatibility
+The current `1.0.2` package line targets ABP `10.0.2`. This package is not retargeted to ABP `10.1.x` in this release line.

--- a/src/Starbender.Mazer.Mvc/Nuget.md
+++ b/src/Starbender.Mazer.Mvc/Nuget.md
@@ -1,3 +1,6 @@
 # Starbender.Mazer.Mvc
 ## ℹ️ Description
 A full featured UI theme kit for [ABP Framework](https://abp.io) applications. It supports Blazor Server, WebAssembly and WebApp architectures. Blazor theme components are based on [MudBlazor](https://mudblazor.com). In addition, MVC UI apps are supported and consistent components are provided to produce a consistent look and feel across all UI technologies.
+
+## Compatibility
+The current `1.0.2` package line targets ABP `10.0.2`. This package is not retargeted to ABP `10.1.x` in this release line.

--- a/src/Starbender.Mazer.Server/Nuget.md
+++ b/src/Starbender.Mazer.Server/Nuget.md
@@ -1,3 +1,6 @@
 # Starbender.Mazer.Server
 ## ℹ️ Description
 A full featured UI theme kit for [ABP Framework](https://abp.io) applications. It supports Blazor Server, WebAssembly and WebApp architectures. Blazor theme components are based on [MudBlazor](https://mudblazor.com). In addition, MVC UI apps are supported and consistent components are provided to produce a consistent look and feel across all UI technologies.
+
+## Compatibility
+The current `1.0.2` package line targets ABP `10.0.2`. This package is not retargeted to ABP `10.1.x` in this release line.

--- a/src/Starbender.Mazer.Shared/Nuget.md
+++ b/src/Starbender.Mazer.Shared/Nuget.md
@@ -1,3 +1,6 @@
 # Starbender.Mazer.Shared
 ## ℹ️ Description
 A full featured UI theme kit for [ABP Framework](https://abp.io) applications. It supports Blazor Server, WebAssembly and WebApp architectures. Blazor theme components are based on [MudBlazor](https://mudblazor.com). In addition, MVC UI apps are supported and consistent components are provided to produce a consistent look and feel across all UI technologies.
+
+## Compatibility
+The current `1.0.2` package line targets ABP `10.0.2`. This package is not retargeted to ABP `10.1.x` in this release line.

--- a/src/Starbender.Mazer.WebAssembly.Bundling/Nuget.md
+++ b/src/Starbender.Mazer.WebAssembly.Bundling/Nuget.md
@@ -1,3 +1,6 @@
 # Starbender.Mazer.WebAssembly.Bundling
 ## ℹ️ Description
 A full featured UI theme kit for [ABP Framework](https://abp.io) applications. It supports Blazor Server, WebAssembly and WebApp architectures. Blazor theme components are based on [MudBlazor](https://mudblazor.com). In addition, MVC UI apps are supported and consistent components are provided to produce a consistent look and feel across all UI technologies.
+
+## Compatibility
+The current `1.0.2` package line targets ABP `10.0.2`. This package is not retargeted to ABP `10.1.x` in this release line.

--- a/src/Starbender.Mazer.WebAssembly/Nuget.md
+++ b/src/Starbender.Mazer.WebAssembly/Nuget.md
@@ -2,3 +2,5 @@
 ## ℹ️ Description
 A full featured UI theme kit for [ABP Framework](https://abp.io) applications. It supports Blazor Server, WebAssembly and WebApp architectures. Blazor theme components are based on [MudBlazor](https://mudblazor.com). In addition, MVC UI apps are supported and consistent components are provided to produce a consistent look and feel across all UI technologies.
 
+## Compatibility
+The current `1.0.2` package line targets ABP `10.0.2`. This package is not retargeted to ABP `10.1.x` in this release line.


### PR DESCRIPTION
## Summary

- Updates README and NuGet documentation to explicitly state that the 1.0.2 package line is pinned to ABP 10.0.2 and does not yet target 10.1.x.
- Fixes asset loading in the Blazor WebApp demo by adding `WebAssemblyStyleFiles` and `WebAssemblyScriptFiles` attributes to the `AbpStyles` and `AbpScripts` components.
- Improves migration documentation regarding `Theme.Shared` imports and WebApp bundling requirements.

## Testing

- [X] I built the relevant projects locally
- [X] I ran tests relevant to this change
- [X] I updated documentation when needed

## Checklist

- [X] This PR targets the correct branch
- [X] This change is scoped to a single feature, fix, or refactor
- [X] Related issues are linked when applicable
